### PR TITLE
Don't die on error (ECONNREFUSE for example)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var events = require('events');
 var Chrome = require('./lib/chrome.js');
 
-module.exports = function (options, callback) {
+module.exports = function (options, callback, errorCallback) {
     if (typeof options === 'function') {
         callback = options;
         options = undefined;
@@ -10,6 +10,9 @@ module.exports = function (options, callback) {
     if (typeof callback === 'function') {
         notifier.on('connect', callback);
     }
+    notifier.on('error', function onError(err) {
+        errorCallback(err);
+    });
     // allow to register callbacks later
     process.nextTick(function () {
         // the default listener just disconnects from Chrome, this can be used


### PR DESCRIPTION
Pros: 
 * error handling, you can retry or handle the error outside the module in whatever way.
 * backwards compatibility (new argument added at the end) 
 * usage simply changed from  `chrome(options, callback)` to  `chrome(options, callback, errorCallback)`

Cons: 
 * doesn't quite follow nodejs pattern, it probably should be used as `chrome(options, callback)` where `callback` is `function(err, chrome)` instead of `function(chrome)`, but that would be a very breaking change and require everybody to adjust their code.