### PR TITLE
Workaround custom inspection behavior causing errors

### DIFF
--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -160,6 +160,11 @@ function addCommand(domainName, command) {
 function addEvent(domainName, event) {
     var self = this;
     self[domainName][event.name] = function (handler) {
+        // Handle node.js custom inspection behavior
+        // https://nodejs.org/api/util.html#util_custom_inspect_function_on_objects
+        if (typeof handler === 'number' && event.name === 'inspect') {
+            return util.inspect(self[domainName], {customInspect: false});
+        }
         self.on(domainName + '.' + event.name, handler);
     };
     self[domainName][event.name].help = prepareHelp('event', event);


### PR DESCRIPTION
Calling `util.inspect` or `console.log` on an object that has an `inspect` property with a function as a value will cause that function to be invoked as part of their custom inspection behavior (https://nodejs.org/api/util.html#util_custom_inspect_function_on_objects). One of the Chrome events is named 'inspect' so this function can be called if you try to console.log the chrome instance. Normally that would throw an error since `handler` would not be a function, but this change will detect that case and avoid trying to attach a handler.

Should fix #15 