### PR TITLE
export a `connect` function

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const EventEmitter = require('events');
 
 const devtools = require('./lib/devtools.js');
-const Chrome = require('./lib/chrome.js');
+const CDPProxy = require('./lib/chrome.js');
 
 function connect(options, callback) {
     if (typeof options === 'function') {
@@ -14,7 +14,7 @@ function connect(options, callback) {
     if (typeof callback === 'function') {
         // allow to register the error callback later
         process.nextTick(function () {
-            new Chrome(options, notifier);
+            new CDPProxy(options, notifier);
         });
         return notifier.on('connect', callback);
     } else {
@@ -24,7 +24,7 @@ function connect(options, callback) {
             notifier.on('disconnect', function () {
                 reject(new Error('Disconnected'));
             });
-            new Chrome(options, notifier);
+            new CDPProxy(options, notifier);
         });
     }
 }

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const EventEmitter = require('events');
 const devtools = require('./lib/devtools.js');
 const Chrome = require('./lib/chrome.js');
 
-module.exports = function (options, callback) {
+function connect(options, callback) {
     if (typeof options === 'function') {
         callback = options;
         options = undefined;
@@ -27,13 +27,15 @@ module.exports = function (options, callback) {
             new Chrome(options, notifier);
         });
     }
-};
+}
 
 // for backward compatibility
+module.exports = connect;
 module.exports.listTabs = devtools.List;
 module.exports.spawnTab = devtools.New;
 module.exports.closeTab = devtools.Close;
 
+module.exports.connect = connect;
 module.exports.Protocol = devtools.Protocol;
 module.exports.List = devtools.List;
 module.exports.New = devtools.New;

--- a/test/connect.js
+++ b/test/connect.js
@@ -8,7 +8,7 @@ describe('connecting to Chrome', function () {
     describe('with callback', function () {
         describe('with default parameters', function () {
             it('should succeed with "connect" callback passed as an argument', function (done) {
-                Chrome(function (chrome) {
+                Chrome.connect(function (chrome) {
                     chrome.close(done);
                 }).on('error', function () {
                     assert(false);
@@ -17,7 +17,7 @@ describe('connecting to Chrome', function () {
         });
         describe('with custom parameters', function () {
             it('should succeed with "connect" callback passed as an argument', function (done) {
-                Chrome({'host': 'localhost', 'port': 9222}, function (chrome) {
+                Chrome.connect({'host': 'localhost', 'port': 9222}, function (chrome) {
                     chrome.close(done);
                 }).on('error', function () {
                     assert(false);
@@ -26,7 +26,7 @@ describe('connecting to Chrome', function () {
         });
         describe('with custom (wrong) parameters', function () {
             it('should fail (wrong port)', function (done) {
-                Chrome({'port': 1}, function () {
+                Chrome.connect({'port': 1}, function () {
                     assert(false);
                 }).on('error', function (err) {
                     assert(err instanceof Error);
@@ -34,7 +34,7 @@ describe('connecting to Chrome', function () {
                 });
             });
             it('should fail (wrong host)', function (done) {
-                Chrome({'host': '255.255.255.255'}, function () {
+                Chrome.connect({'host': '255.255.255.255'}, function () {
                     assert(false);
                 }).on('error', function (err) {
                     assert(err instanceof Error);
@@ -42,7 +42,7 @@ describe('connecting to Chrome', function () {
                 });
             });
             it('should fail (wrong tab)', function (done) {
-                Chrome({'chooseTab': function () { return -1; }}, function () {
+                Chrome.connect({'chooseTab': function () { return -1; }}, function () {
                     assert(false);
                 }).on('error', function (err) {
                     assert(err instanceof Error);
@@ -52,8 +52,8 @@ describe('connecting to Chrome', function () {
         });
         describe('two times', function () {
             it('should fail', function (done) {
-                Chrome(function (chrome) {
-                    Chrome(function () {
+                Chrome.connect(function (chrome) {
+                    Chrome.connect(function () {
                         assert(false);
                     }).on('error', function (err) {
                         assert(err instanceof Error);
@@ -68,7 +68,7 @@ describe('connecting to Chrome', function () {
     describe('without callback', function () {
         describe('with default parameters', function () {
             it('should succeed', function (done) {
-                Chrome().then(function (chrome) {
+                Chrome.connect().then(function (chrome) {
                     chrome.close(done);
                 }).catch(function () {
                     assert(false);
@@ -77,7 +77,7 @@ describe('connecting to Chrome', function () {
         });
         describe('with custom parameters', function () {
             it('should succeed', function (done) {
-                Chrome({'host': 'localhost', 'port': 9222}).then(function (chrome) {
+                Chrome.connect({'host': 'localhost', 'port': 9222}).then(function (chrome) {
                     chrome.close(done);
                 }).catch(function () {
                     assert(false);
@@ -86,7 +86,7 @@ describe('connecting to Chrome', function () {
         });
         describe('with custom (wrong) parameters', function () {
             it('should fail (wrong port)', function (done) {
-                Chrome({'port': 1}).then(function () {
+                Chrome.connect({'port': 1}).then(function () {
                     assert(false);
                 }).catch(function (err) {
                     assert(err instanceof Error);
@@ -94,7 +94,7 @@ describe('connecting to Chrome', function () {
                 });
             });
             it('should fail (wrong host)', function (done) {
-                Chrome({'host': '255.255.255.255'}).then(function () {
+                Chrome.connect({'host': '255.255.255.255'}).then(function () {
                     assert(false);
                 }).catch(function (err) {
                     assert(err instanceof Error);
@@ -102,7 +102,7 @@ describe('connecting to Chrome', function () {
                 });
             });
             it('should fail (wrong tab)', function (done) {
-                Chrome({'chooseTab': function () { return -1; }}).then(function () {
+                Chrome.connect({'chooseTab': function () { return -1; }}).then(function () {
                     assert(false);
                 }).catch(function (err) {
                     assert(err instanceof Error);
@@ -112,8 +112,8 @@ describe('connecting to Chrome', function () {
         });
         describe('two times', function () {
             it('should fail', function (done) {
-                Chrome(function (chrome) {
-                    Chrome().then(function () {
+                Chrome.connect(function (chrome) {
+                    Chrome.connect().then(function () {
                         assert(false);
                     }).catch(function (err) {
                         assert(err instanceof Error);


### PR DESCRIPTION
Current recommended syntax appears to use the module as a class - `Chrome` is capitalized and is a noun rather than a verb. This PR proposes exporting an additional `connect` method that does exactly what the main export does now, but which would allow a more intuitive syntax:

```
let cdp = require('chrome-remote-interface');
cdp.connect(options, (chrome) => { chrome.Profiler.start(); });
```

The old syntax still works too, so tests still pass even without refactoring.