### PR TITLE
Add Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,7 +527,7 @@ For example:
 const CDP = require('chrome-remote-interface');
 CDP.Activate({'id': 'CC46FBFA-3BDA-493B-B2E4-2BE6EB0D97EC'}, function (err) {
     if (!err) {
-        console.log('success! tab is closing');
+        console.log('success! tab is activated');
     }
 });
 ```

--- a/examples/recipes.js
+++ b/examples/recipes.js
@@ -1,0 +1,98 @@
+const CDP = require('..');
+
+/*
+ - log the network requests sent
+ - close when the page is loaded
+*/
+function handleConnection(client) {
+    with (client) {
+        Network.requestWillBeSent(function (params) {
+            console.log(params.request.url);
+        });
+        Page.loadEventFired(function () {
+            close();
+        });
+        Network.enable();
+        Page.enable();
+        once('ready', function () {
+            Page.navigate({'url': 'https://github.com'});
+        });
+    }
+}
+
+/*
+  - startup logic
+  - resume node process if it's waiting on the debugger
+  - log the new scripts
+*/
+function handleNodeConnection(client) {
+    with (client) {
+        Runtime.enable();
+        Debugger.enable();
+        Debugger.setPauseOnExceptions({'state': 'none'});
+        Debugger.setAsyncCallStackDepth({'maxDepth': 0});
+        Runtime.runIfWaitingForDebugger();
+
+        Debugger.scriptParsed(resp => console.log(resp));
+    }
+}
+
+/*
+  1. connect with the default host and port
+  2. choose the default tab (0)
+*/
+function simpleConnection() {
+    CDP(handleConnection).on('error', console.error);
+}
+
+
+/*
+  Connection with a promise handler.
+*/
+function promiseConnection() {
+    CDP().then(handleConnection).catch(console.error);
+}
+
+/*
+  Connection with a couple of options
+  1. set a port (same as default)
+  2. override the chooseTab logic
+*/
+function connectionWithOptions() {
+    CDP({
+        port: 9222,
+        chooseTab: () => 0
+    })
+      .then(handleConnection)
+      .catch( e => console.error(e));
+}
+
+/*
+  Connect to node and list parsed scripts
+*/
+function connectToNode() {
+    CDP({port: 9229}).then(handleNodeConnection);
+}
+
+/*
+  list chrome tabs
+*/
+function listTabs() {
+    CDP.List({port: 9222}, console.log);
+}
+
+/*
+  list chrome tabs with a promise handler
+*/
+function promiseListTabs() {
+    CDP.List({port: 9229}.then(console.log(tabs)
+}
+
+// Examples
+
+// simpleConnection();
+// promiseConnection();
+// connectionWithOptions();
+// connectToNode();
+// listTabs();
+// promiseListTabs();


### PR DESCRIPTION
Thanks @cyrus-and for a great project.

The Firefox DevTools team is working on a standalone JS Debugger, which speaks CDP with Node and Chrome. We've been using our own [connection backend](https://github.com/jasonLaster/chrome-remote-debugging-protocol), which rips Chrome's InspectorBackend and bootstrap logic. 

I'm going to work on switching over to chrome remote interface so that we can share a common implementation. 

Feel free to disregard this PR, I felt like sharing some of my throwaway examples so that others could benefit from them.

Perhaps they're merged into the README or merged as is so others can get up and running a little faster. Your README is very readable, but somewhat terse so i found it helpful to test the different interface options here.