### PR TITLE
Fix #311

### DIFF
--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -149,7 +149,7 @@ function start() {
         // update the connection parameters using the debugging URL
         const urlObject = parseUrl(url);
         options.host = urlObject.hostname;
-        options.port = urlObject.port;
+        options.port = urlObject.port || options.port;
         // fetch the protocol and prepare the API
         return fetchProtocol.call(chrome, options).then(api.prepare.bind(chrome));
     }).then(function (values) {


### PR DESCRIPTION
Set passed port when using standard port while parsing webSocketDebuggerUrl which returns null port