### PR TITLE
Not close WebSocket if it is already closed

### DIFF
--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -98,13 +98,18 @@ class Chrome extends EventEmitter {
 
     close(callback) {
         const closeWebSocket = (callback) => {
-            // don't notify on user-initiated shutdown ('disconnect' event)
-            this._ws.removeAllListeners('close');
-            this._ws.close();
-            this._ws.once('close', () => {
-                this._ws.removeAllListeners();
+            //don't close if it's already closed
+            if (this._ws.readyState === 3) {
                 callback();
-            });
+            } else {
+                // don't notify on user-initiated shutdown ('disconnect' event)
+                this._ws.removeAllListeners('close');
+                this._ws.once('close', () => {
+                    this._ws.removeAllListeners();
+                    callback();
+                });
+                this._ws.close();
+            }
         };
         if (typeof callback === 'function') {
             closeWebSocket(callback);

--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -98,7 +98,7 @@ class Chrome extends EventEmitter {
 
     close(callback) {
         const closeWebSocket = (callback) => {
-            //don't close if it's already closed
+            // don't close if it's already closed
             if (this._ws.readyState === 3) {
                 callback();
             } else {


### PR DESCRIPTION
If you call close twice the second time the Promises are not called. 

That is because WebSocket doesn't emit the onclose event in that case.
