### PR TITLE
Remove chrome listeners on close.

### DIFF
--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -104,6 +104,7 @@ class Chrome extends EventEmitter {
             } else {
                 // don't notify on user-initiated shutdown ('disconnect' event)
                 this._ws.removeAllListeners('close');
+                this.removeAllListeners();
                 this._ws.once('close', () => {
                     this._ws.removeAllListeners();
                     callback();


### PR DESCRIPTION
If the chrome's listeners are not removed on close and there are listeners in user's  code,  script inconsistently fails giving below error as it tries to execute the listeners when the connection is already closed. 
```
Error: not opened
    at WebSocket.send (/.../node_modules/chrome-remote-interface/node_modules/ws/lib/WebSocket.js:359:18)
    at Chrome._enqueueCommand (/.../node_modules/chrome-remote-interface/lib/chrome.js:272:18)
    at Promise (/../node_modules/chrome-remote-interface/lib/chrome.js:84:22)
    at new Promise (<anonymous>)
    at Chrome.send (/.../node_modules/chrome-remote-interface/lib/chrome.js:83:20)
    at Object.handler [as getDocument] (/.../node_modules/chrome-remote-interface/lib/api.js:32:23)
    at Chrome.<anonymous> (/../test.js:44:60)
    at Chrome.emit (events.js:182:13)
    at Chrome._handleMessage (/.../node_modules/chrome-remote-interface/lib/chrome.js:261:18)
    at WebSocket._ws.on (/.../node_modules/chrome-remote-interface/lib/chrome.js:225:22)
``` 