### PR TITLE
Bump up ws to 6.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3224,7 +3224,8 @@
         "safe-buffer": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-            "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+            "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+            "dev": true
         },
         "semver": {
             "version": "5.5.1",
@@ -3541,11 +3542,6 @@
             "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
             "dev": true
         },
-        "ultron": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-            "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
-        },
         "url": {
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
@@ -3717,13 +3713,11 @@
             }
         },
         "ws": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-            "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.0.tgz",
+            "integrity": "sha512-H3dGVdGvW2H8bnYpIDc3u3LH8Wue3Qh+Zto6aXXFzvESkTVT6rAfKR6tR/+coaUvxs8yHtmNV0uioBF62ZGSTg==",
             "requires": {
-                "async-limiter": "~1.0.0",
-                "safe-buffer": "~5.1.0",
-                "ultron": "~1.1.0"
+                "async-limiter": "~1.0.0"
             }
         },
         "xtend": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     },
     "dependencies": {
         "commander": "2.11.x",
-        "ws": "^3.3.3"
+        "ws": "^6.1.0"
     },
     "files": [
         "lib",


### PR DESCRIPTION
This PR upgrades `ws` to the latest stable version.

All tests pass.