### PR TITLE
Use idempotent babel polyfill to make sure consumer don't get more than one babel-polyfill instance error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3243,6 +3243,15 @@
                 "safer-buffer": ">= 2.1.2 < 3"
             }
         },
+        "idempotent-babel-polyfill": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/idempotent-babel-polyfill/-/idempotent-babel-polyfill-6.26.0.tgz",
+            "integrity": "sha512-SX8KVhb0Uu6RnMhPnkXcr/H5zy76axdCO2VlI8j8vQUTbitNKjHrpk5JxbQuJ4/ykbRSNmUJ65YE29t32e1Wqw==",
+            "dev": true,
+            "requires": {
+                "babel-polyfill": "^6.26.0"
+            }
+        },
         "ieee754": {
             "version": "1.1.13",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",

--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
     "devDependencies": {
         "babel-core": "^6.26.3",
         "babel-loader": "6.x.x",
-        "babel-polyfill": "^6.26.0",
         "babel-preset-env": "^1.7.0",
         "eslint": "^4.19.1",
+        "idempotent-babel-polyfill": "^6.26.0",
         "json-loader": "^0.5.4",
         "mocha": "^5.2.0",
         "webpack": "^4.35.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,7 @@ module.exports = {
             './external-request.js': `var (${criWrapper})`
         }
     ],
-    entry: ['babel-polyfill', './index.js'],
+    entry: ['idempotent-babel-polyfill', './index.js'],
     output: {
         path: __dirname,
         filename: 'chrome-remote-interface.js',


### PR DESCRIPTION
## Summary
When the consumer application of this package is already importing `babel-polyfill` then it leads to the following problem:
https://github.com/babel/babel/issues/4019

Possible solutions:
- Remove the babel-polyfill as an entry and make it as an external peer dependency. It will upto the consumer on how to provide it.
- Use `idemportent-babel-polyfill` to have a safe initialization.

## Related threads:
- https://github.com/babel/babel/issues/4019
- https://github.com/transcranial/keras-js/issues/109