### PR TITLE
feat: add sendRaw function

### DIFF
--- a/README.md
+++ b/README.md
@@ -797,6 +797,30 @@ For example:
 client.send('Page.navigate', {url: 'https://github.com'}, console.log);
 ```
 
+#### client.sendRaw(message, [callback])
+
+Issue a raw message to the remote instance.
+
+`message` is a raw message object according to the Chrome DevTools protocol.
+`message.id` does not need to be set, if it is not passed, a unique ID will
+be generated.
+
+`sendRaw` can be useful when you need lower-level control, like if you need to
+pass a `sessionId` with your command to scope it to a specific target.
+
+A `callback` can be passed. If omitted, a `Promise` is returned. See
+`client.send` for more information.
+
+For example:
+
+```js
+client.sendRaw({
+  method: 'Page.navigate',
+  params: { url: 'https://github.com' },
+  sessionId: 'some session ID',
+}, console.log);
+```
+
 #### client.`<domain>`.`<method>`([params], [callback])
 
 Just a shorthand for:

--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -78,19 +78,26 @@ class Chrome extends EventEmitter {
             callback = params;
             params = undefined;
         }
+
+        return this.sendRaw({
+            method,
+            params: params || {}
+        }, callback);
+    }
+
+    sendRaw(message, callback) {
         // return a promise when a callback is not provided
         if (typeof callback === 'function') {
-            this._enqueueCommand(method, params, callback);
+            this._enqueueCommand(message, callback);
             return undefined;
         } else {
             return new Promise((fulfill, reject) => {
-                this._enqueueCommand(method, params, (error, response) => {
+                this._enqueueCommand(message, (error, response) => {
                     if (error) {
-                        const request = {method, params};
                         reject(
                             error instanceof Error
                                 ? error // low-level WebSocket error
-                                : new ProtocolError(request, response)
+                                : new ProtocolError(message, response)
                         );
                     } else {
                         fulfill(response);
@@ -272,12 +279,9 @@ class Chrome extends EventEmitter {
     }
 
     // send a command to the remote endpoint and register a callback for the reply
-    _enqueueCommand(method, params, callback) {
+    _enqueueCommand(message, callback) {
         const id = this._nextCommandId++;
-        const message = {
-            id, method,
-            params: params || {}
-        };
+        message = { id, ...message };
         this._ws.send(JSON.stringify(message), (err) => {
             if (err) {
                 // handle low-level WebSocket errors
@@ -285,7 +289,7 @@ class Chrome extends EventEmitter {
                     callback(err);
                 }
             } else {
-                this._callbacks[id] = callback;
+                this._callbacks[message.id] = callback;
             }
         });
     }

--- a/test/send.js
+++ b/test/send.js
@@ -140,4 +140,17 @@ describe('sending a command', () => {
             });
         });
     });
+    describe('using sendRaw', () => {
+        it('should succeed', (done) => {
+            Chrome((chrome) => {
+                chrome.sendRaw({
+                    method: 'Network.setCacheDisabled',
+                    params: {'cacheDisabled': true}
+                }, (error, response) => {
+                    assert(!error);
+                    chrome.close(done);
+                });
+            });
+        });
+    });
 });


### PR DESCRIPTION
Closes #439 

Adds a `sendRaw` function that lets the user manually construct a CDP message. This way, the user has control over parameters like `sessionId`, unlocking the full capabilities of CDP.