### PR TITLE
Add event listener for each domain 

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -57,12 +57,32 @@ function addType(chrome, domainName, type) {
     chrome[domainName][type.id] = help;
 }
 
+function addDomainListener(chrome, domainName) {
+    const handler = (_eventName, handler) => {
+        const eventName = `${domainName}.${_eventName}`;
+        if (typeof handler === 'function') {
+            chrome.on(eventName, handler);
+            return () => chrome.removeListener(eventName, handler);
+        } else {
+            return new Promise((fulfill, reject) => {
+                chrome.once(eventName, fulfill);
+            });
+        }
+    };
+    chrome[domainName].on = handler;
+}
+
+
 function prepare(object, protocol) {
     // assign the protocol and generate the shorthands
     object.protocol = protocol;
     protocol.domains.forEach((domain) => {
         const domainName = domain.domain;
         object[domainName] = {};
+
+        // Add listener for each domain
+        addDomainListener(object, domainName);
+
         // add commands
         (domain.commands || []).forEach((command) => {
             addCommand(object, domainName, command);


### PR DESCRIPTION
Add event listener for each domain to allow event to be called without using full namespace.

Closes: https://github.com/cyrus-and/chrome-remote-interface/issues/443

Example:
```javascript
const client = CDP({ host: 'host', port: 'port' });
client.Page.on('screencastFrame', frame => {
  // Handle frame
});
```

Compared to now:
```javascript
const client = CDP({ host: 'host', port: 'port' });
client.on('Page.screencastFrame', frame => {
  // Handle frame
});
// or
client.Page.screencastFrame(frame => {
  // Handle frame
});
```
Typings are hard to produce for the last example since eventNames are not separated in the type information provided by the `devtools-protocol`. 

```typescript
export interface Events {
  /**
  * Compressed image data requested by the `startScreencast`.
  */
  'Page.screencastFrame': [Protocol.Page.ScreencastFrameEvent];
}
```

However Domain specific listeners do exist:
```typescript
export interface PageApi {
  /**
  * Compressed image data requested by the `startScreencast`.
  */
  on(event: 'screencastFrame', listener: (params: Protocol.Page.ScreencastFrameEvent) => void): void;
```

So we could end up with a scenario like this at least:
![image](https://user-images.githubusercontent.com/5993909/103755064-828ce200-500d-11eb-97e3-b22620636f29.png)

Instead of this:
![image](https://user-images.githubusercontent.com/5993909/103755102-933d5800-500d-11eb-9310-bd35ee0c2384.png)

It would be awesome with typings for this:
```
client.Page.screencastFrame(frame => {
  // Handle frame
});
```
But they would have to be generated somehow and that would be cumbersome.