### PR TITLE
Add support for `client['Domain.Event']` syntax for Promise-based event type checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -866,6 +866,16 @@ Close the connection to the remote instance.
 
 When `callback` is omitted a `Promise` object is returned.
 
+#### client['`<domain>`.`<name>`']
+
+Just a shorthand for:
+
+```js
+client.<domain>.<name>
+```
+
+Where `<name>` can be a command, an event, or a type.
+
 ## FAQ
 
 ### Invoking `Domain.method` I obtain `Domain.method is not a function`

--- a/lib/api.js
+++ b/lib/api.js
@@ -53,7 +53,7 @@ function addEvent(chrome, domainName, event) {
         }
     };
     decorate(handler, 'event', event);
-    chrome[domainName][event.name] = handler;
+    chrome[eventName] = chrome[domainName][event.name] = handler;
 }
 
 function addType(chrome, domainName, type) {

--- a/lib/api.js
+++ b/lib/api.js
@@ -28,11 +28,12 @@ function decorate(to, category, object) {
 }
 
 function addCommand(chrome, domainName, command) {
+    const commandName = `${domainName}.${command.name}`;
     const handler = (params, sessionId, callback) => {
-        return chrome.send(`${domainName}.${command.name}`, params, sessionId, callback);
+        return chrome.send(commandName, params, sessionId, callback);
     };
     decorate(handler, 'command', command);
-    chrome[domainName][command.name] = handler;
+    chrome[commandName] = chrome[domainName][command.name] = handler;
 }
 
 function addEvent(chrome, domainName, event) {
@@ -57,9 +58,10 @@ function addEvent(chrome, domainName, event) {
 }
 
 function addType(chrome, domainName, type) {
+    const typeName = `${domainName}.${type.id}`;
     const help = {};
     decorate(help, 'type', type);
-    chrome[domainName][type.id] = help;
+    chrome[typeName] = chrome[domainName][type.id] = help;
 }
 
 function prepare(object, protocol) {


### PR DESCRIPTION
This pr adds support for `client['Domain.Event']` syntax that has the same semantics as `client['Domain']['Event']`, with an example given below:

```js
await client['Page.loadEventFired'];  // equivalent to await client['Page']['loadEventFired'];
```

The reason for this pr is that the `client['Domain.Event']` syntax allows TypeScript type checking of that expression with regard to the current capabilities of TypeScript and the current contents of `devtools-protocol`'s [protocol-mapping.d.ts](https://github.com/ChromeDevTools/devtools-protocol/blob/06ee96a2575cbc80d84588030dff3daa7723ed93/types/protocol-mapping.d.ts), as can be seen at https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54049.

I understand that this pr adds perhaps a small amount of bloat, but I'm not sure whether a pr sent to `devtools-protocol` will succeed. It is currently beyond my abilities to change TypeScript.