### PR TITLE
add forSession

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -29,8 +29,8 @@ function decorate(to, category, object) {
 
 function addCommand(chrome, domainName, command) {
     const commandName = `${domainName}.${command.name}`;
-    const handler = (params, sessionId, callback) => {
-        return chrome.send(commandName, params, sessionId, callback);
+    const handler = function (params, callback)  {
+        return this.send(commandName, params, this.sessionId, callback);
     };
     decorate(handler, 'command', command);
     chrome[commandName] = chrome[domainName][command.name] = handler;
@@ -38,18 +38,18 @@ function addCommand(chrome, domainName, command) {
 
 function addEvent(chrome, domainName, event) {
     const eventName = `${domainName}.${event.name}`;
-    const handler = (sessionId, handler) => {
+    const handler = function (sessionId, handler) {
         if (typeof sessionId === 'function') {
             handler = sessionId;
             sessionId = undefined;
         }
         const rawEventName = sessionId ? `${eventName}.${sessionId}` : eventName;
         if (typeof handler === 'function') {
-            chrome.on(rawEventName, handler);
-            return () => chrome.removeListener(rawEventName, handler);
+            this.on(rawEventName, handler);
+            return () => this.removeListener(rawEventName, handler);
         } else {
             return new Promise((fulfill, reject) => {
-                chrome.once(rawEventName, fulfill);
+                this.once(rawEventName, fulfill);
             });
         }
     };
@@ -64,12 +64,12 @@ function addType(chrome, domainName, type) {
     chrome[typeName] = chrome[domainName][type.id] = help;
 }
 
-function prepare(object, protocol) {
+function prepare(object, protocol, chrome) {
     // assign the protocol and generate the shorthands
     object.protocol = protocol;
     protocol.domains.forEach((domain) => {
         const domainName = domain.domain;
-        object[domainName] = {};
+        object[domainName] = Object.create(chrome);
         // add commands
         (domain.commands || []).forEach((command) => {
             addCommand(object, domainName, command);

--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -61,6 +61,9 @@ class Chrome extends EventEmitter {
         this._notifier = notifier;
         this._callbacks = {};
         this._nextCommandId = 1;
+        this.SessionChrome = function SessionCrhome(sessionId){
+            this.sessionId = sessionId;
+        }
         // properties
         this.webSocketUrl = undefined;
         // operations
@@ -126,6 +129,12 @@ class Chrome extends EventEmitter {
         }
     }
 
+    forSession(sessionId){
+        const sessionChrome = new this.SessionChrome(sessionId);
+        Object.setPrototypeOf(sessionChrome, this);
+        return sessionChrome;
+    }
+
     // initiate the connection process
     async _start() {
         const options = {
@@ -147,7 +156,10 @@ class Chrome extends EventEmitter {
             options.port = urlObject.port || options.port;
             // fetch the protocol and prepare the API
             const protocol = await this._fetchProtocol(options);
-            api.prepare(this, protocol);
+            let protocolObject = {}
+            api.prepare(protocolObject, protocol, this);
+            this.SessionChrome.prototype = protocolObject
+            Object.assign(this, protocolObject)
             // finally connect to the WebSocket
             await this._connectToWebSocket();
             // since the handler is executed synchronously, the emit() must be


### PR DESCRIPTION
If we handle id for CDP, why not also handle sessionId, example:
```js
const CDP = require('chrome-remote-interface');

async function example() {
    let client;
    try {
        // connect to endpoint
        client = await CDP();
        // extract domains
        const {Page} = client;
        // setup handlers
        let {targetId} = await client.Target.createTarget({ url: 'about:blank'});
        let {sessionID} = await client.Target.attachToTarget({targetId, flatten: true,});

        // sessionId is now attached to pageClient
        const pageClient = client.forSession(sessionId);

        pageClient.Page.navigate({ url: 'https://github.com' })

    } catch (err) {
        console.error(err);
    } finally {
        if (client) {
            await client.close();
        }
    }
}

example();
```
