### PR TITLE
Reject CDP commands when connection closed

### DIFF
--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -63,8 +63,6 @@ class Chrome extends EventEmitter {
         this._nextCommandId = 1;
         // properties
         this.webSocketUrl = undefined;
-        this.webSocketProtocols = options.wsProtocols;
-        this.webSocketOptions = options.wsOptions;
         // operations
         this._start();
     }
@@ -222,9 +220,7 @@ class Chrome extends EventEmitter {
                 if (this.secure) {
                     this.webSocketUrl = this.webSocketUrl.replace(/^ws:/i, 'wss:');
                 }
-                this._ws = new WebSocket(this.webSocketUrl,
-                    this.webSocketProtocols,
-                    this.webSocketOptions);
+                this._ws = new WebSocket(this.webSocketUrl);
             } catch (err) {
                 // handles bad URLs
                 reject(err);

--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -63,6 +63,8 @@ class Chrome extends EventEmitter {
         this._nextCommandId = 1;
         // properties
         this.webSocketUrl = undefined;
+        this.webSocketProtocols = options.wsProtocols;
+        this.webSocketOptions = options.wsOptions;
         // operations
         this._start();
     }
@@ -220,7 +222,9 @@ class Chrome extends EventEmitter {
                 if (this.secure) {
                     this.webSocketUrl = this.webSocketUrl.replace(/^ws:/i, 'wss:');
                 }
-                this._ws = new WebSocket(this.webSocketUrl);
+                this._ws = new WebSocket(this.webSocketUrl,
+                    this.webSocketProtocols,
+                    this.webSocketOptions);
             } catch (err) {
                 // handles bad URLs
                 reject(err);

--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -111,6 +111,7 @@ class Chrome extends EventEmitter {
                 this._ws.removeAllListeners('close');
                 this._ws.once('close', () => {
                     this._ws.removeAllListeners();
+                    this._handleConnectionClose();
                     callback();
                 });
                 this._ws.close();
@@ -235,6 +236,7 @@ class Chrome extends EventEmitter {
                 this._handleMessage(message);
             });
             this._ws.on('close', (code) => {
+                this._handleConncetionClose();
                 this.emit('disconnect');
             });
             this._ws.on('error', (err) => {
@@ -243,6 +245,13 @@ class Chrome extends EventEmitter {
         });
     }
 
+    _handleConnectionClose() {
+        const err = new Error('WebSocket connection closed');
+        for (const callback of Object.values(this._callbacks)) {
+            callback(true, err);
+        }
+        this._callbacks = {};
+    }
     // handle the messages read from the WebSocket
     _handleMessage(message) {
         // command response

--- a/test/send.js
+++ b/test/send.js
@@ -79,6 +79,19 @@ describe('sending a command', () => {
             });
         });
     });
+    it('should catch WebSocket errors after command send', (done) => {
+        Chrome((chrome) => {
+            let result;
+            chrome.Page.enable((err, res)=>{
+                result = res;
+            });
+            chrome.close(()=>{
+                assert(result instanceof Error);
+                assert(result.message === 'WebSocket connection closed');
+                done();
+            });
+        });
+    });
     describe('without a callback', () => {
         it('should fulfill the promise if the command succeeds', (done) => {
             Chrome((chrome) => {


### PR DESCRIPTION
Handle situation when CDP request was send, but response was not received yet. E.g:
- send CDP request (no response yet)
- connection closed

In this case we need to reject CDP command promise (Page.navigate for exampe) instead of waitig forever.