### PR TITLE
Reject callbacks on socket close with Error

### DIFF
--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -251,9 +251,9 @@ class Chrome extends EventEmitter {
 
     _handleConnectionClose() {
         // make sure to complete all the unresolved callbacks
-        const err = new Error('WebSocket connection closed');
+        const error = new Error('WebSocket connection closed');
         for (const callback of Object.values(this._callbacks)) {
-            callback(true, err);
+            callback(error);
         }
         this._callbacks = {};
     }

--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -251,9 +251,9 @@ class Chrome extends EventEmitter {
 
     _handleConnectionClose() {
         // make sure to complete all the unresolved callbacks
-        const error = new Error('WebSocket connection closed');
+        const err = new Error('WebSocket connection closed');
         for (const callback of Object.values(this._callbacks)) {
-            callback(error);
+            callback(err);
         }
         this._callbacks = {};
     }

--- a/test/send.js
+++ b/test/send.js
@@ -81,15 +81,17 @@ describe('sending a command', () => {
     });
     it('should catch WebSocket errors after command send', (done) => {
         Chrome((chrome) => {
-            let result;
-            chrome.Page.enable((err, res)=>{
-                result = res;
-            });
-            chrome.close(()=>{
-                assert(result instanceof Error);
-                assert(result.message === 'WebSocket connection closed');
+            chrome.Runtime.evaluate({
+                expression: 'new Promise(_ => _)',
+                awaitPromise: true
+            }, (error, response) => {
+                assert(error instanceof Error);
+                assert(!error.request);
+                assert(!error.response);
+                assert(!response);
                 done();
             });
+            chrome.close();
         });
     });
     describe('without a callback', () => {


### PR DESCRIPTION
Using true for first argument is expected for ProtocolError, which is not the case