### PR TITLE
Add CDP debug option that will log any request and response sent over the protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@ Connects to a remote instance using the [Chrome Debugging Protocol].
 - `host`: HTTP frontend host. Defaults to `localhost`;
 - `port`: HTTP frontend port. Defaults to `9222`;
 - `secure`: HTTPS/WSS frontend. Defaults to `false`;
+- `debug`: logs over console every CDP message send and received;
 - `useHostName`: do not perform a DNS lookup of the host. Defaults to `false`;
 - `alterPath`: a `function` taking and returning the path fragment of a URL
   before that a request happens. Defaults to the identity function;

--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -57,7 +57,9 @@ class Chrome extends EventEmitter {
         this.protocol = options.protocol;
         this.local = !!(options.local);
         this.target = options.target || defaultTarget;
+        this.debug = options.debug;
         // locals
+        this._debugLog = [];
         this._notifier = notifier;
         this._callbacks = {};
         this._nextCommandId = 1;
@@ -261,6 +263,7 @@ class Chrome extends EventEmitter {
     // handle the messages read from the WebSocket
     _handleMessage(message) {
         // command response
+        if (this.debug) console.log('CDP OUT ::', JSON.stringify(message))
         if (message.id) {
             const callback = this._callbacks[message.id];
             if (!callback) {
@@ -268,12 +271,14 @@ class Chrome extends EventEmitter {
             }
             // interpret the lack of both 'error' and 'result' as success
             // (this may happen with node-inspector)
+            if (this.debug) message.debugSent = this._debugLog[message.id];
             if (message.error) {
                 callback(true, message.error);
             } else {
                 callback(false, message.result || {});
             }
             // unregister command response callback
+            if (this.debug) delete this._debugLog[message.id];
             delete this._callbacks[message.id];
             // notify when there are no more pending commands
             if (Object.keys(this._callbacks).length === 0) {
@@ -298,7 +303,12 @@ class Chrome extends EventEmitter {
             sessionId,
             params: params || {}
         };
-        this._ws.send(JSON.stringify(message), (err) => {
+        let jsonMessage = JSON.stringify(message);
+        if (this.debug) {
+            this._debugLog[id] = jsonMessage;
+            if (this.debug) console.log('CDP IN :::', jsonMessage)
+        }
+        this._ws.send(jsonMessage, (err) => {
             if (err) {
                 // handle low-level WebSocket errors
                 if (typeof callback === 'function') {


### PR DESCRIPTION
I sought a streamlined method to learn and debug CDP, and it appears that there isn't a readily available solution. Consequently, I took the initiative to implement an addition in this regard. While the decision to accept this addition is at your discretion, I believe its modest size and potential utility for others warrant consideration.