### PR TITLE
Add abortSignal argument to constructor

### DIFF
--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -64,7 +64,7 @@ class Chrome extends EventEmitter {
         // properties
         this.webSocketUrl = undefined;
         // operations
-        this._start();
+        this._start(options.signal);
     }
 
     // avoid misinterpreting protocol's members as custom util.inspect functions
@@ -128,13 +128,14 @@ class Chrome extends EventEmitter {
     }
 
     // initiate the connection process
-    async _start() {
+    async _start(signal) {
         const options = {
             host: this.host,
             port: this.port,
             secure: this.secure,
             useHostName: this.useHostName,
-            alterPath: this.alterPath
+            alterPath: this.alterPath,
+            signal: signal
         };
         try {
             // fetch the WebSocket debugger URL
@@ -150,7 +151,7 @@ class Chrome extends EventEmitter {
             const protocol = await this._fetchProtocol(options);
             api.prepare(this, protocol);
             // finally connect to the WebSocket
-            await this._connectToWebSocket();
+            await this._connectToWebSocket(signal);
             // since the handler is executed synchronously, the emit() must be
             // performed in the next tick so that uncaught errors in the client code
             // are not intercepted by the Promise mechanism and therefore reported
@@ -214,7 +215,7 @@ class Chrome extends EventEmitter {
     }
 
     // establish the WebSocket connection and start processing user commands
-    _connectToWebSocket() {
+    _connectToWebSocket(signal) {
         return new Promise((fulfill, reject) => {
             // create the WebSocket
             try {
@@ -246,6 +247,12 @@ class Chrome extends EventEmitter {
             this._ws.on('error', (err) => {
                 reject(err);
             });
+            if (signal) {
+                signal.addEventListener('abort', (reason) => {
+                    this._ws.close();
+                    reject(reason);
+                });
+            }
         });
     }
 

--- a/lib/devtools.js
+++ b/lib/devtools.js
@@ -14,7 +14,8 @@ function devToolsInterface(path, options, callback) {
         host: options.host || defaults.HOST,
         port: options.port || defaults.PORT,
         useHostName: options.useHostName,
-        path: (options.alterPath ? options.alterPath(path) : path)
+        path: (options.alterPath ? options.alterPath(path) : path),
+        signal: options.signal,
     };
     externalRequest(transport, requestOptions, callback);
 }


### PR DESCRIPTION
Supporting `AbortSignal` would be a great improvement to the API.
I've started by passing it in the constructor although a similar PR for the `send` method is needed.

You can run something like this to see the result:
```
import cri from './index.js';

const abortController = new AbortController();
const conn = cri({ signal: abortController.signal });
abortController.abort();
await conn;
```